### PR TITLE
Add Read and Show instances for Jid

### DIFF
--- a/source/Network/Xmpp.hs
+++ b/source/Network/Xmpp.hs
@@ -48,6 +48,7 @@ module Network.Xmpp
   , isFull
   , jidFromText
   , jidFromTexts
+  , toJid
   , getJid
   -- * Stanzas
   -- | The basic protocol data unit in XMPP is the XML stanza. The stanza is


### PR DESCRIPTION
Here's a hack with `Read' and`Show' instances for Jid, as discussed.
I didn't have the time or patience to make it elegant, but at least it
does the job.

I'm calling it `jid' instead of`toJid' for the time-being since
`toJid' is already used in the stream configuration record.

Fixes #24.
