### PR TITLE
Update dependency of crypto-random-api to crypto-random.

### DIFF
--- a/pontarius-xmpp.cabal
+++ b/pontarius-xmpp.cabal
@@ -47,7 +47,7 @@ Library
                , conduit              >=1.0.1
                , containers           >=0.4.0.0
                , crypto-api           >=0.9
-               , crypto-random-api    >=0.2
+               , crypto-random        >=0.0.5
                , cryptohash           >=0.6.1
                , cryptohash-cryptoapi >=0.1
                , data-default         >=0.2

--- a/source/Network/Xmpp/Tls.hs
+++ b/source/Network/Xmpp/Tls.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_HADDOCK hide #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
 
 module Network.Xmpp.Tls where
 
@@ -8,7 +9,7 @@ import qualified Control.Exception.Lifted as Ex
 import           Control.Monad
 import           Control.Monad.Error
 import           Control.Monad.State.Strict
-import           Crypto.Random.API
+import "crypto-random" Crypto.Random
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC8
 import qualified Data.ByteString.Lazy as BL
@@ -121,7 +122,8 @@ tlsinit :: (MonadIO m, MonadIO m1) =>
           )
 tlsinit params backend = do
     liftIO $ debugM "Pontarius.Xmpp.Tls" "TLS with debug mode enabled."
-    gen <- liftIO $ getSystemRandomGen -- TODO: Find better random source?
+    pool <- liftIO $ createEntropyPool
+    let gen = cprgCreate pool :: SystemRNG
     con <- client params gen backend
     handshake con
     let src = forever $ do


### PR DESCRIPTION
_tls-extra-0.6.5_ depends on _crypto-random_ instead of _crypto-random-api_ now. Both _crypto-random_ and _crypto-random-api_ export `Crypto.Random.API` module. 
As a result, pontarius-xmpp failed to build. Package-qualified import won't help. 

I'm not totally sure my modifications are correct, but it builds and works fine in my xmppbot.
