### PR TITLE
Unpickle an element even if it contains ContextEntity in its attributes

### DIFF
--- a/source/Network/Xmpp/Stream.hs
+++ b/source/Network/Xmpp/Stream.hs
@@ -833,7 +833,8 @@ elements = do
     goE n as = do
         (y, ns) <- many' goN
         if y == Just (EventEndElement n)
-            then return $ Element n as $ compressNodes ns
+            then return $ Element n (map (id >< compressContents) as)
+                                    (compressNodes ns)
             else lift $ R.monadThrow $ InvalidXmppXml $
                                          "Missing close tag: " ++ show n
     goN = do
@@ -852,6 +853,13 @@ elements = do
     compressNodes (NodeContent (ContentText x) : NodeContent (ContentText y) : z) =
         compressNodes $ NodeContent (ContentText $ x `Text.append` y) : z
     compressNodes (x:xs) = x : compressNodes xs
+
+    compressContents :: [Content] -> [Content]
+    compressContents cs = [ContentText $ Text.concat (map unwrap cs)]
+        where unwrap (ContentText t) = t
+              unwrap (ContentEntity t) = t
+
+    (><) f g (x, y) = (f x, g y)
 
 withStream :: StateT StreamState IO a -> Stream -> IO a
 withStream action (Stream stream) = Ex.bracketOnError


### PR DESCRIPTION
Hi. I'm a user of this product and appreciate it.

I found that the connection is disconnected when I receive xml element which contains entity context in its attributes.

for example)

```
<presence to='xxxx@chat.hipchat.com/none' from='yyyy@conf.hipchat.com/&quot;Hiratara&quot;'><x xmlns='http://jabber.org/protocol/muc#user'><item affiliation='member' jid='zzz@chat.hipchat.com' role='participant'/></x></presence>
```

This patch fix the problem.

Thanks.
