### PR TITLE
Update pontarius-xmpp.cabal

### DIFF
--- a/pontarius-xmpp.cabal
+++ b/pontarius-xmpp.cabal
@@ -57,7 +57,7 @@ Library
                , resourcet            >=0.3.0
                , random               >=1.0.0.0
                , split                >=0.1.2.3
-               , stm                  >=2.1.2.1
+               , stm                  >=2.4
                , stringprep           >=1.0.0
                , text                 >=0.11.1.5
                , tls                  >=1.2


### PR DESCRIPTION
Change in build-depends, package stm: version >= 2.4 is needed because of the use of the function 'cloneTChan'
