### PR TITLE
Make keepAlive time optional

### DIFF
--- a/source/Network/Xmpp/Concurrent.hs
+++ b/source/Network/Xmpp/Concurrent.hs
@@ -187,6 +187,7 @@ newSession stream config realm mbSasl = runErrorT $ do
                         ]
     (kill, sState, reader) <- ErrorT $ startThreadsWith writeSem stanzaHandler
                                                         eh stream
+                                                        (keepAlive config)
     idGen <- liftIO $ sessionStanzaIDs config
     let sess = Session { stanzaCh = stanzaChan
                        , iqHandlers = iqHands

--- a/source/Network/Xmpp/Concurrent/Types.hs
+++ b/source/Network/Xmpp/Concurrent/Types.hs
@@ -96,6 +96,9 @@ data SessionConfiguration = SessionConfiguration
                                           -> PeerStatus
                                           -> PeerStatus
                                           -> IO ())
+      -- | How often to send keep-alives
+      --   'Nothing' disables keep-alive
+    , keepAlive                  :: Maybe Int
     }
 
 instance Default SessionConfiguration where
@@ -111,6 +114,7 @@ instance Default SessionConfiguration where
                                , enableRoster = True
                                , enablePresenceTracking = True
                                , onPresenceChange = Nothing
+                               , keepAlive = Just 30
                                }
 
 -- | Handlers to be run when the Xmpp session ends and when the Xmpp connection is


### PR DESCRIPTION
Some clients may do manual ping actions that already keep the connection
alive, or be run in environments where they otherwise know the
keep-alive conditions are different from the default.

Especially on mobile, we want to keep radio usage down, so doing
keep-alive in application logic is likely (I am doing this in txtmpp with SMACKS stanzas).