### PR TITLE
Bump tls to version 1.3.9

### DIFF
--- a/pontarius-xmpp.cabal
+++ b/pontarius-xmpp.cabal
@@ -62,7 +62,7 @@ Library
                , stm                  >=2.4
                , stringprep           >=1.0.0
                , text                 >=0.11.1.5
-               , tls                  >=1.3
+               , tls                  >=1.3.9
                , transformers         >=0.3
                , unbounded-delays     >=0.1
                , void                 >=0.5.5

--- a/source/Network/Xmpp/Types.hs
+++ b/source/Network/Xmpp/Types.hs
@@ -109,7 +109,7 @@ import qualified Language.Haskell.TH.Syntax as TH
 #endif
 import           Network
 import           Network.DNS
-import           Network.TLS hiding (Version)
+import           Network.TLS hiding (Version, HostName)
 import           Network.TLS.Extra
 import qualified Text.StringPrep as SP
 import qualified Text.StringPrep.Profiles as SP


### PR DESCRIPTION
hs-tls fixed an [issue](https://github.com/vincenthz/hs-tls/issues/152) regarding ECDSA certificates in version 1.3.9

This commit simply requires at least that version of tls and makes
pontarius-xmpp compile using that newer hs-tls version.