### PR TITLE
Patches for compiling on a recent stack

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -2,19 +2,22 @@
 {-# OPTIONS_GHC -Wall #-}
 module Main (main) where
 
-import Distribution.Package ( PackageName, Package, PackageId, InstalledPackageId, packageVersion, packageName, unPackageName )
 import Distribution.PackageDescription ( PackageDescription(), TestSuite(..) )
+import Distribution.Pretty ( prettyShow )
 import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )
-import Distribution.Simple.Utils ( rewriteFile, createDirectoryIfMissingVerbose, copyFiles, ordNub )
-import Distribution.Simple.BuildPaths ( autogenModulesDir )
-import Distribution.Simple.Setup ( BuildFlags(buildVerbosity), Flag(..), fromFlag, HaddockFlags(haddockDistPref))
-import Distribution.Simple.LocalBuildInfo ( withLibLBI, withTestLBI, LocalBuildInfo(), ComponentLocalBuildInfo(componentPackageDeps) )
-import Distribution.Text ( display )
+import Distribution.Simple.Flag ( fromFlag )
+import Distribution.Simple.Utils ( rewriteFileEx, createDirectoryIfMissingVerbose, ordNub )
+import Distribution.Simple.BuildPaths ( autogenPackageModulesDir )
+import Distribution.Simple.Setup ( BuildFlags(buildVerbosity) )
+import Distribution.Simple.LocalBuildInfo ( withTestLBI, LocalBuildInfo, componentPackageDeps )
+import Distribution.Types.Component ( foldComponent )
+import Distribution.Types.LocalBuildInfo ( allTargetsInBuildOrder' )
 import Distribution.Types.MungedPackageId ( MungedPackageId(mungedName, mungedVersion) )
-import Distribution.Types.MungedPackageName ( MungedPackageName, unMungedPackageName )
+import Distribution.Types.MungedPackageName ( encodeCompatPackageName )
+import Distribution.Types.PackageName ( unPackageName )
+import Distribution.Types.TargetInfo ( TargetInfo (targetComponent,targetCLBI) )
 import Distribution.Types.UnqualComponentName ( unUnqualComponentName )
-import Distribution.Verbosity ( Verbosity, normal )
-import Distribution.Version ( showVersion )
+import Distribution.Verbosity ( Verbosity )
 import System.FilePath ( (</>) )
 
 main :: IO ()
@@ -26,20 +29,22 @@ main = defaultMainWithHooks simpleUserHooks
 
 generateBuildModule :: Verbosity -> PackageDescription -> LocalBuildInfo -> IO ()
 generateBuildModule verbosity pkg lbi = do
-  let dir = autogenModulesDir lbi
+  let dir = autogenPackageModulesDir lbi
   createDirectoryIfMissingVerbose verbosity True dir
-  withLibLBI pkg lbi $ \_ libcfg -> do
-    withTestLBI pkg lbi $ \suite suitecfg -> do
+  let libdeps = concatMap (componentPackageDeps . targetCLBI) $
+                filter (foldComponent (const True) (const False) (const False)
+                                (const False) (const False) . targetComponent) $
+                allTargetsInBuildOrder' pkg lbi
+  withTestLBI pkg lbi $ \suite suitecfg -> do
       let testSuiteName = unUnqualComponentName (testName suite)
-      rewriteFile (dir </> "Build_" ++ testSuiteName ++ ".hs") $ unlines
+          testSuiteDeps = ordNub $ componentPackageDeps suitecfg ++ libdeps
+      rewriteFileEx verbosity (dir </> "Build_" ++ testSuiteName ++ ".hs") $ unlines
         [ "module Build_" ++ testSuiteName ++ " where"
         , "deps :: [String]"
-        , "deps = " ++ (show $ formatdeps (testDeps libcfg suitecfg))
+        , "deps = " ++ (show $ formatdeps testSuiteDeps)
         ]
   where
     formatdeps = map (formatone . snd)
     formatone p =
-      unMungedPackageName (mungedName p) ++ "-" ++ showVersion (mungedVersion p)
-
-testDeps :: ComponentLocalBuildInfo -> ComponentLocalBuildInfo -> [(InstalledPackageId, MungedPackageId)]
-testDeps xs ys = ordNub $ componentPackageDeps xs ++ componentPackageDeps ys
+      unPackageName (encodeCompatPackageName (mungedName p))
+        ++ "-" ++ prettyShow (mungedVersion p)

--- a/source/Network/Xmpp/Concurrent.hs
+++ b/source/Network/Xmpp/Concurrent.hs
@@ -30,7 +30,7 @@ import qualified Data.Map as Map
 import           Data.Maybe
 import           Data.Text as Text
 import           Data.XML.Types
-import           Network
+import           Network.Socket
 import           Network.Xmpp.Concurrent.Basic
 import           Network.Xmpp.Concurrent.IQ
 import           Network.Xmpp.Concurrent.Message

--- a/source/Network/Xmpp/Concurrent/Presence.hs
+++ b/source/Network/Xmpp/Concurrent/Presence.hs
@@ -49,5 +49,5 @@ sendPresence p session = sendStanza (PresenceS checkedP) session
     -- potential instant messaging and presence contact, the value of the 'to'
     -- attribute MUST be a bare JID rather than a full JID
     checkedP = case presenceType p of
-        Subscribe -> p & to . _Just %~ toBare
+        Subscribe -> p & to . some_ %~ toBare
         _ -> p

--- a/source/Network/Xmpp/Concurrent/Types.hs
+++ b/source/Network/Xmpp/Concurrent/Types.hs
@@ -15,7 +15,7 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Typeable
 import           Data.XML.Types (Element)
-import           Network
+import           Network.Socket
 import           Network.Xmpp.IM.Roster.Types
 import           Network.Xmpp.IM.PresenceTracker.Types
 import           Network.Xmpp.Sasl.Types

--- a/source/Network/Xmpp/Stream.hs
+++ b/source/Network/Xmpp/Stream.hs
@@ -37,7 +37,7 @@ import           Data.Word (Word16)
 import           Data.XML.Pickle
 import           Data.XML.Types
 import qualified GHC.IO.Exception as GIE
-import           Network
+import           Network.Socket hiding (Stream,connect)
 import           Network.DNS hiding (encode, lookup)
 import qualified Network.Socket as S
 import           Network.Socket (AddrInfo)
@@ -654,17 +654,6 @@ connectSrv config host = do
                     "The hostname could not be validated."
                 throwError XmppIllegalTcpDetails
   where for = flip fmap
-
-showPort :: PortID -> String
-#if MIN_VERSION_network(2, 4, 1)
-showPort = show
-#else
-showPort (PortNumber x) = "PortNumber " ++ show x
-showPort (Service x) = "Service " ++ show x
-#if !defined(mingw32_HOST_OS) && !defined(__MINGW32__)
-showPort (UnixSocket x) = "UnixSocket " ++ show x
-#endif
-#endif
 
 connectHandle :: AddrInfo -> IO Handle
 connectHandle addrInfo = do

--- a/source/Network/Xmpp/Types.hs
+++ b/source/Network/Xmpp/Types.hs
@@ -108,7 +108,7 @@ import           Language.Haskell.TH
 import           Language.Haskell.TH.Quote
 import qualified Language.Haskell.TH.Syntax as TH
 #endif
-import           Network
+import           Network.Socket
 import           Network.DNS
 import           Network.TLS hiding (Version, HostName)
 import           Network.TLS.Extra
@@ -945,9 +945,9 @@ jid = QuasiQuoter { quoteExp = \s -> do
                           case jidFromText t of
                               Nothing -> fail $ "Could not parse JID " ++ s
                               Just j -> TH.lift j
-                  , quotePat = fail "Jid patterns aren't implemented"
-                  , quoteType = fail "jid QQ can't be used in type context"
-                  , quoteDec  = fail "jid QQ can't be used in declaration context"
+                  , quotePat = error "Jid patterns aren't implemented"
+                  , quoteType = error "jid QQ can't be used in type context"
+                  , quoteDec  = error "jid QQ can't be used in declaration context"
                   }
 
 -- | Synonym for 'jid'
@@ -1000,11 +1000,11 @@ langTagQ = QuasiQuoter {quoteExp = \s -> case langTagFromText $ Text.pack  s of
                                                       map textE (subtags lt))
                                         |]
 
-                       , quotePat = fail $ "LanguageTag patterns aren't"
+                       , quotePat = error $ "LanguageTag patterns aren't"
                                          ++ " implemented"
-                       , quoteType = fail $ "LanguageTag QQ can't be used"
+                       , quoteType = error $ "LanguageTag QQ can't be used"
                                            ++ " in type context"
-                       , quoteDec  = fail $ "LanguageTag QQ can't be used"
+                       , quoteDec  = error $ "LanguageTag QQ can't be used"
                                            ++ " in declaration context"
 
                        }

--- a/tests/Doctest.hs
+++ b/tests/Doctest.hs
@@ -21,7 +21,6 @@ main = doctest $
   : "-XQuasiQuotes"
   : "-XOverloadedStrings"
   : "-DWITH_TEMPLATE_HASKELL"
-  : "-optP-includedist/build/autogen/cabal_macros.h"
   : map ("-package="++) deps
     ++ sources
 

--- a/tests/Run/SendReceive.hs
+++ b/tests/Run/SendReceive.hs
@@ -13,7 +13,7 @@ import qualified Data.Configurator as Conf
 import qualified Data.Configurator.Types as Conf
 import           Data.Maybe
 import qualified Data.Text as Text
-import           Network
+import           Network.Socket
 import           Network.Xmpp
 import           System.Exit
 import           System.Log.Logger

--- a/tests/Tests/Arbitrary/Xmpp.hs
+++ b/tests/Tests/Arbitrary/Xmpp.hs
@@ -28,7 +28,7 @@ instance Arbitrary NonemptyText where
 
 instance Arbitrary Jid where
     arbitrary = do
-        Just jid <- tryJid `suchThat` isJust
+        ~(Just jid) <- tryJid `suchThat` isJust
         return jid
       where
         tryJid = jidFromTexts <$> maybeGen (genString nodeprepProfile False)


### PR DESCRIPTION
Hi,

I've had to patch a few things to get pontarius-xmpp to build on a recent stack, so I figure it can be useful to others.

Mostly this entails:

* Cabal 3.0 (I suppose it's 2.0-compatible, but haven't tested)
* MonadFail (GHC >= 8.8)
* network >= 3.0
* lens-family >= 2.0

This is really just me updating stuff until it compiles, I haven't really
used it yet.

I specifically don't pretend to understand what that codeblock in Setup.hs
tries to achieve.  Or why it ran just fine without the line I removed in
Doctest.hs.

I'm not sure what the compatibility policy is for this project, so merge with care if you're interested.